### PR TITLE
fix: ensure proper type export config

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
     "src/"
   ],
   "exports": {
-    ".": {
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
-    }
+    "types": "./src/index.d.ts",
+    "import": "./lib/index.mjs",
+    "require": "./lib/index.cjs"
   },
   "scripts": {
     "test": "npm run build && cross-env NODE_OPTIONS=--experimental-vm-modules jest --verbose",


### PR DESCRIPTION
Resolves #76. I ran into the same and OP of #76 didn't create a PR as requested by repo maintainer.

Note regarding dropping the wrapper `".": { ... }`, it's only necessary if there are other subpaths. Since this repo only has 1 path, it's not necessary.