### PR TITLE
feat/better intellisense

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Use [smartypants](https://www.npmjs.com/package/smartypants) to easily translate
 
 ```js
 import { marked } from "marked";
-import { markedSmartypants } from "marked-smartypants";
+import { smartypants } from "marked-smartypants";
 
 // or UMD script
 // <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
 // <script src="https://cdn.jsdelivr.net/npm/marked-smartypants/lib/index.umd.js"></script>
 
-marked.use(markedSmartypants());
+marked.use(smartypants());
 
 // or optionally provide smartpants configuration
-// marked.use(markedSmartypants({ config: "1" }));
+// marked.use(smartypants({ config: "1" }));
 
 marked.parse("He said, -- \"A 'simple' sentence. . .\" --- unknown");
 // <p>He said, – “A ‘simple’ sentence…” — unknown</p>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ export default [
   {
     input: 'src/index.js',
     output: {
-      name: 'markedSmartypants',
+      name: 'smartypants',
       file: 'lib/index.umd.js',
       format: 'umd'
     },

--- a/spec/index.test-d.ts
+++ b/spec/index.test-d.ts
@@ -1,9 +1,9 @@
 import { marked } from "marked";
-import { markedSmartypants } from "../src/index";
+import { smartypants } from "../src/index";
 
-marked.use(markedSmartypants());
-marked.use(markedSmartypants({}));
-marked.use(markedSmartypants({ config: "1" }));
-marked.use(markedSmartypants({ config: 1 }));
+marked.use(smartypants());
+marked.use(smartypants({}));
+marked.use(smartypants({ config: "1" }));
+marked.use(smartypants({ config: 1 }));
 
 marked.parse("He said, -- \"A 'simple' sentence. . .\" --- unknown");

--- a/spec/index.test.cjs
+++ b/spec/index.test.cjs
@@ -1,5 +1,5 @@
 const { marked } = require('marked');
-const { markedSmartypants } = require('../lib/index.cjs');
+const { smartypants } = require('../lib/index.cjs');
 const { runTests } = require('./run-tests.cjs');
 
-runTests(marked, markedSmartypants);
+runTests(marked, smartypants);

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -1,5 +1,5 @@
 import { marked } from 'marked';
-import { markedSmartypants } from '../src/index.js';
+import { smartypants } from '../src/index.js';
 import { runTests } from './run-tests.cjs';
 
-runTests(marked, markedSmartypants);
+runTests(marked, smartypants);

--- a/spec/index.test.mjs
+++ b/spec/index.test.mjs
@@ -1,5 +1,5 @@
 import { marked } from 'marked';
-import { markedSmartypants } from '../lib/index.mjs';
+import { smartypants } from '../lib/index.mjs';
 import { runTests } from './run-tests.cjs';
 
-runTests(marked, markedSmartypants);
+runTests(marked, smartypants);

--- a/spec/index.umd.test.js
+++ b/spec/index.umd.test.js
@@ -1,6 +1,6 @@
 import { marked } from 'marked';
 import { runTests } from './run-tests.cjs';
 await import('../lib/index.umd.js');
-const { markedSmartypants } = global.markedSmartypants;
+const { smartypants } = global.smartypants;
 
-runTests(marked, markedSmartypants);
+runTests(marked, smartypants);

--- a/spec/run-tests.cjs
+++ b/spec/run-tests.cjs
@@ -1,12 +1,12 @@
 module.exports = {
-  runTests(marked, markedSmartypants) {
-    describe('markedSmartypants', () => {
+  runTests(marked, smartypants) {
+    describe('smartypants', () => {
       beforeEach(() => {
         marked.setOptions(marked.getDefaults());
       });
 
       test('quotes around em', () => {
-        marked.use(markedSmartypants());
+        marked.use(smartypants());
         expect(marked('"**test**"')).toMatchInlineSnapshot(`
     "<p>&#8220;<strong>test</strong>&#8221;</p>
     "
@@ -14,7 +14,7 @@ module.exports = {
       });
 
       test('simple sentence', () => {
-        marked.use(markedSmartypants());
+        marked.use(smartypants());
         expect(marked('# He said, -- "A \'simple\' sentence. . ." --- unknown', { headerIds: false })).toMatchInlineSnapshot(`
     "<h1>He said, &#8211; &#8220;A &#8216;simple&#8217; sentence&#8230;&#8221; &#8212; unknown</h1>
     "
@@ -22,7 +22,7 @@ module.exports = {
       });
 
       test('leaves codespan', () => {
-        marked.use(markedSmartypants());
+        marked.use(smartypants());
         expect(marked('`He said, -- "A \'simple\' sentence. . ." --- unknown`')).toMatchInlineSnapshot(`
     "<p><code>He said, -- &quot;A &#39;simple&#39; sentence. . .&quot; --- unknown</code></p>
     "
@@ -30,7 +30,7 @@ module.exports = {
       });
 
       test('leaves code block', () => {
-        marked.use(markedSmartypants());
+        marked.use(smartypants());
         expect(marked('```\nHe said, -- "A \'simple\' sentence. . ." --- unknown\n```')).toMatchInlineSnapshot(`
     "<pre><code>He said, -- &quot;A &#39;simple&#39; sentence. . .&quot; --- unknown
     </code></pre>
@@ -39,7 +39,7 @@ module.exports = {
       });
 
       test('supports config', () => {
-        marked.use(markedSmartypants({
+        marked.use(smartypants({
           config: 1
         }));
         expect(marked('# He said, -- "A \'simple\' sentence. . ." --- unknown', { headerIds: false })).toMatchInlineSnapshot(`

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,10 +2,14 @@ import type { marked } from "marked";
 import type { MarkedExtension } from "marked";
 
 /**
- * Add closing slash to tags like: `hr`, `br`, `img`, and `input`
+ * Use [smartypants](https://github.com/othree/smartypants.js) for "smart" typographic punctuation for things like quotes and dashes
  *
  * @returns A {@link MarkedExtension | MarkedExtension} to be passed to {@link marked.use | `marked.use()`}
  */
 export function markedSmartypants(options?: {
+  /**
+   * A number between -1 and 3 for a preset, or a string with letters for typographic rules. See [all options](https://github.com/othree/smartypants.js#options-and-configuration)
+   * @default 2
+   */
   config?: string | number;
 }): MarkedExtension;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import { smartypants } from 'smartypants';
+import { smartypants as smartypantsLib } from 'smartypants';
 
-export function markedSmartypants({
+export function smartypants({
   config = 2
 } = {}) {
   return {
@@ -24,7 +24,7 @@ export function markedSmartypants({
     },
     hooks: {
       postprocess(html) {
-        return smartypants(html, config);
+        return smartypantsLib(html, config);
       }
     }
   };


### PR DESCRIPTION
This is a breaking change as the named export changes. However, all other marked extensions do not have 'marked' as prefix in their named exports. If merged, should be done separately and after #166 

EDIT: it seems there is not really a pattern..
there is `markedHighlight` & `markedSmartypants`, but there is also `gfmHeadingId` & `baseUrl`, so I'm not sure what should be the norm. Feel free to close